### PR TITLE
Ticket 01365/payment service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 API_KEY_COINAPI='coinapi key'
+CARDANO_WALLET_URI='http://127.0.0.1:1089'

--- a/src/Services/PaymentService.php
+++ b/src/Services/PaymentService.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Lidonation\CardanoPayments\Services;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
+// use Symfony\Component\Process\Process;
+
+class PaymentService
+{
+    public $client;
+    public $walletId;
+    public $receiverAddress;
+    public $passPhrase;
+    public $transaction = [
+        'baseCurrency' => null,
+        'paymentCurrency' => null,
+        'baseAmount' => null,
+        'paymentMount' => null,
+        'paymentMountADA' => null,
+        'id' => null,
+    ];
+
+    public function __construct()
+    {
+        $this->client = new Client([
+            'base_uri' => 'http://127.0.0.1:1024',
+            'verify' => false
+        ]);
+    }
+
+    public function transactionInstance($walletId, $receiverAddress, $passPhrase)
+    {
+        $this->walletId = $walletId;
+        $this->receiverAddress = $receiverAddress;
+        $this->passPhrase = $passPhrase;
+
+        return $this;
+    }
+
+    public function processPayment(string $baseCurrency, string $paymentCurrency, $baseAmount, $paymentMount=null)
+    {
+        $this->transaction["baseCurrency"] = $baseCurrency;
+        $this->transaction["paymentCurrency"] = $paymentCurrency;
+        $this->transaction["baseAmount"] = $baseAmount;
+
+        // making sure we have $paymentCurrency and $paymentMount set
+        if ($baseCurrency == $paymentCurrency) {
+            $this->transaction["paymentMount"] = $paymentMount ?? $baseAmount;
+        } else {
+            $rateObj = new ExchangeRateService($baseCurrency, $paymentCurrency);
+            $this->transaction["paymentMount"] = $rateObj->rate * $baseAmount;
+        }
+
+        // converting our $paymentMount to ADA then to lovelace
+        $this->transaction["paymentMountADA"] =  $this->convertToAda($this->transaction["paymentCurrency"], $this->transaction["paymentMount"]);
+        $lovelaceMount = $this->convertToLovelace($this->transaction["paymentMountADA"]);
+
+        // excecute the transaction and return transaction id
+        $this->transaction["id"] = $this->executeTransaction($lovelaceMount);
+        return $this->transaction["id"];
+    }
+
+    public function convertToAda(string $currency, $amount)
+    {
+        $rate = $this->getAdaRate($currency);
+        return $rate * $amount;
+    }
+
+    public function convertToLovelace(float $adaAmount): float
+    {
+        return $adaAmount * 1000000;
+    }
+
+    public function getAdaRate(string $currency)
+    {
+        $exchObj = ($currency != "ADA") ? new ExchangeRateService($currency, "ADA") : 1.0;
+        return  $exchObj->rate ??  $exchObj;
+    }
+
+    public function executeTransaction($lovelaceAmount)
+    {
+        $constructString = $this->transactionConstruct($lovelaceAmount);
+        $signString = $this->transactionSign($constructString);
+        if (!is_null($signString)) {
+            $submitString = $this->transactionSubmit($signString);
+        }
+        
+
+        return $submitString;
+
+    }
+
+    //returns transaction hash for the signing process's payload
+    public function transactionConstruct($lovelaceAmount)
+    {
+        try {
+
+            $payload = [
+                "payments" => [
+                      [
+                         "address" => $this->receiverAddress, 
+                         "amount" => [
+                            "quantity" => $lovelaceAmount, 
+                            "unit" => "lovelace" 
+                         ] 
+                      ] 
+                ],
+                "withdrawal" => "self"
+
+             ];
+
+            $path = "/v2/wallets/{$this->walletId}/transactions-construct";
+            $response = $this->client->request("POST", $path, ['json'=>$payload]);
+            if ($response->getStatusCode() == 200 || $response->getStatusCode() == 202) {
+                $responseBody = json_decode($response->getBody(), true);
+                return $responseBody['transaction'];
+            } else {
+                return null;
+            }
+
+        } catch (BadResponseException $e) {
+            return true;
+        }
+
+    }
+
+    // returns transaction hash for submit process's payload
+    public function transactionSign(string $transaction)
+    {   
+        try {
+            $payload = [
+                'passphrase' => $this->passPhrase,
+                'transaction' => $transaction
+            ];
+    
+            $path = "/v2/wallets/{$this->walletId}/transactions-sign";
+            $response =  $this->client->request("POST", $path, ['json'=>$payload]);
+            if ($response->getStatusCode() == 200 || $response->getStatusCode() == 202) {
+                $responseBody = json_decode($response->getBody(), true);
+                return $responseBody['transaction'];
+            } else {
+                return null;
+            }
+        } catch (BadResponseException $e) {
+            return null;
+        }
+
+    }
+
+    // returns transaction id 
+    public function transactionSubmit(string $transaction)
+    {
+        try {
+            $payload = [
+                'transaction' => $transaction
+            ];
+    
+            $path = "/v2/wallets/{$this->walletId}/transactions-submit";
+            $response =  $this->client->request("POST", $path, ['json'=>$payload]);
+            if ($response->getStatusCode() == 200 || $response->getStatusCode() == 202) {
+                $responseBody = json_decode($response->getBody(), true);
+                return $responseBody['id'];
+            } else {
+                return null;
+            }
+        } catch (BadResponseException $e) {
+            return null;
+        }
+    }
+}

--- a/src/Services/PaymentService.php
+++ b/src/Services/PaymentService.php
@@ -2,6 +2,7 @@
 
 namespace Lidonation\CardanoPayments\Services;
 
+use Dotenv\Dotenv;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 // use Symfony\Component\Process\Process;
@@ -23,8 +24,12 @@ class PaymentService
 
     public function __construct()
     {
+        // load enviroment variables
+        $dotenv = Dotenv::createImmutable(dirname(dirname(dirname(__FILE__))));
+        $dotenv->load();
+
         $this->client = new Client([
-            'base_uri' => 'http://127.0.0.1:1024',
+            'base_uri' => $_ENV['CARDANO_WALLET_URI'],
             'verify' => false
         ]);
     }

--- a/tests/PaymentServiceTest.php
+++ b/tests/PaymentServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Lidonation\CardanoPayments\Services\ExchangeRateService;
 use Lidonation\CardanoPayments\Services\PaymentService;
 
@@ -8,14 +9,13 @@ it('can convert to ADA', function () {
     $mockPy->shouldReceive("getAdaRate")
         ->andReturn(2.8)
         ->getMock();
-    
+
 
     expect($mockPy->convertToAda("USD", 4))->toEqual(11.2);
-
 });
 
-it("can convert to lovelace", function() {
-    $service =  new PaymentService();
+it("can convert to lovelace", function () {
+    $service = new PaymentService();
     expect($service->convertToLovelace(5))->toEqual(5000000);
 });
 
@@ -25,10 +25,10 @@ it('can service payments', function () {
     $receiverAddress = "addr_test1qpree0hx36cyh9x8fgjv3e3286h0dutkh2pluk37kjwu2uzxd5qvkr8hg48q96mavlpa37rw909v6ppah90ntz2d3rws6796ra";
     $passPhrase = "test123456";
 
-    
+
     $pay = new PaymentService();
     $payMwas = $pay->transactionInstance($walletId, $receiverAddress, $passPhrase);
-   
+
     expect($pay->transactionSubmit($pay->transactionSign($pay->transactionConstruct(1000000))))->toBeString();
     // expect($payMwas->processPayment("ADA", "ADA", 0.5))->toBeString();
 });

--- a/tests/PaymentServiceTest.php
+++ b/tests/PaymentServiceTest.php
@@ -1,0 +1,34 @@
+<?php
+use Lidonation\CardanoPayments\Services\ExchangeRateService;
+use Lidonation\CardanoPayments\Services\PaymentService;
+
+it('can convert to ADA', function () {
+    $service = new ExchangeRateService();
+    $mockPy = mock(PaymentService::class)->makePartial();
+    $mockPy->shouldReceive("getAdaRate")
+        ->andReturn(2.8)
+        ->getMock();
+    
+
+    expect($mockPy->convertToAda("USD", 4))->toEqual(11.2);
+
+});
+
+it("can convert to lovelace", function() {
+    $service =  new PaymentService();
+    expect($service->convertToLovelace(5))->toEqual(5000000);
+});
+
+//assign walletId, $receiverAddress and $passPhrase to test transactions on the testnet
+it('can service payments', function () {
+    $walletId = "1c6c7d5c39573df8ee6c50b35cbd510b8a0334f1";
+    $receiverAddress = "addr_test1qpree0hx36cyh9x8fgjv3e3286h0dutkh2pluk37kjwu2uzxd5qvkr8hg48q96mavlpa37rw909v6ppah90ntz2d3rws6796ra";
+    $passPhrase = "test123456";
+
+    
+    $pay = new PaymentService();
+    $payMwas = $pay->transactionInstance($walletId, $receiverAddress, $passPhrase);
+   
+    expect($pay->transactionSubmit($pay->transactionSign($pay->transactionConstruct(1000000))))->toBeString();
+    // expect($payMwas->processPayment("ADA", "ADA", 0.5))->toBeString();
+});


### PR DESCRIPTION
tests for payment require the user to provide walletId, receiver address, and passphrase which I saw no need to have in the environment variables. The provided value examples work on testnet preprod.